### PR TITLE
Change migration class name from Log to LogMigration

### DIFF
--- a/access.analyser/Migrations/20200515184316_Log.Designer.cs
+++ b/access.analyser/Migrations/20200515184316_Log.Designer.cs
@@ -11,7 +11,7 @@ namespace access.analyser.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
     [Migration("20200515184316_Log")]
-    partial class Log
+    partial class LogMigration
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {

--- a/access.analyser/Migrations/20200515184316_Log.cs
+++ b/access.analyser/Migrations/20200515184316_Log.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace access.analyser.Migrations
 {
-    public partial class Log : Migration
+    public partial class LogMigration : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {


### PR DESCRIPTION
Zmieniłem nazwę klasy migracji, bo kolidowała z klasą w modelu. Moje niedopatrzenie jak tworzyłem migracje.
Drugi porządkowy PR w ciągu tej godziny. :P