### PR TITLE
Add sns notification through lambda

### DIFF
--- a/Lambda/src/Lambda/Lambda.csproj
+++ b/Lambda/src/Lambda/Lambda.csproj
@@ -7,9 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.0.1" />
-    <PackageReference Include="AWSSDK.Core" Version="3.3.107.3" />
-    <PackageReference Include="AWSSDK.KeyManagementService" Version="3.3.105.55" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.111.2" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.107.6" />
+    <PackageReference Include="AWSSDK.KeyManagementService" Version="3.3.106.2" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.111.7" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.101.178" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Lambda/src/Lambda/LambdaFunction.cs
+++ b/Lambda/src/Lambda/LambdaFunction.cs
@@ -10,6 +10,7 @@ using Lambda.Models;
 using Lambda.Parsing;
 using Lambda.Database;
 using System.Linq;
+using Lambda.SNS;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -39,6 +40,8 @@ namespace Lambda
                 var entries = retriever.GetObjectDataAsync().Select(
                     logLine => EntryParser.ProcessLogLine(logLine));
                 await logSaver.SaveLogsAsync(logId, entries).ConfigureAwait(false);
+                if (NotificationSender.IsNotificationNecessary(data.Value.objectsKey))
+                    await NotificationSender.TryPublishNotification(data.Value.objectsKey).ConfigureAwait(false);
             }
             else
             {

--- a/Lambda/src/Lambda/SNS/NotificationSender.cs
+++ b/Lambda/src/Lambda/SNS/NotificationSender.cs
@@ -1,0 +1,54 @@
+﻿using Amazon.Runtime;
+using Amazon.SimpleNotificationService;
+using Amazon.SimpleNotificationService.Model;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lambda.SNS
+{
+    public static class NotificationSender
+    {
+        public static bool IsNotificationNecessary(string objectsKey)
+        {
+            Contract.Requires(objectsKey != null);
+            var trimmedKey = objectsKey.Substring(0, objectsKey.Length - 4);
+            trimmedKey = trimmedKey.Substring(trimmedKey.LastIndexOf('-')+1);
+            int logNumToday = Int32.Parse(trimmedKey,CultureInfo.InvariantCulture);
+            var logNumLimitStr = Environment.GetEnvironmentVariable("LOGLIMIT");
+            var logNumLimit = logNumLimitStr is null ? 10 :
+                Int32.Parse(logNumLimitStr, CultureInfo.InvariantCulture);
+            Console.WriteLine($"Request number {logNumToday}, Notification Threshold is {logNumLimit}");
+            return logNumToday == logNumLimit;
+
+        }
+        public static async Task TryPublishNotification(string objectsKey)
+        {
+            string topicArn = Environment.GetEnvironmentVariable("TOPICARN");
+            using var client = new AmazonSimpleNotificationServiceClient(Amazon.RegionEndpoint.USEast1);
+            var request = new PublishRequest
+            {
+                TopicArn = topicArn,
+                Message = "User sent too many logs today, objectKey" +
+                " ({userId}-{TodaysDate}-{#of log sent today}.log)=" + objectsKey,
+                Subject = "Access.analyser - too many logs"
+            };
+            try
+            {
+                await client.PublishAsync(request).ConfigureAwait(false);
+                Console.WriteLine("Successfully published notification");
+            }
+            catch(AmazonClientException e)
+            {
+                Console.WriteLine("failed to send message" + e);
+            }
+            catch (AmazonSimpleNotificationServiceException e)
+            {
+                Console.WriteLine("failed to send message" + e);
+            }
+        }
+    }
+}

--- a/access.analyser.sln
+++ b/access.analyser.sln
@@ -22,7 +22,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CloudFormationTemplates", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2FA879FC-DADA-41A0-9ED8-2DCDA954667B}"
 	ProjectSection(SolutionItems) = preProject
-		abc.json = abc.json
 		appspec.yml = appspec.yml
 		buildspec.yml = buildspec.yml
 	EndProjectSection

--- a/access.analyser.sln
+++ b/access.analyser.sln
@@ -22,6 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CloudFormationTemplates", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2FA879FC-DADA-41A0-9ED8-2DCDA954667B}"
 	ProjectSection(SolutionItems) = preProject
+		abc.json = abc.json
 		appspec.yml = appspec.yml
 		buildspec.yml = buildspec.yml
 	EndProjectSection

--- a/templates/s3lambda.template
+++ b/templates/s3lambda.template
@@ -49,6 +49,17 @@
             "Type"        : "String",
             "MinLength"   : 3,
             "MaxLength"   : 63
+        },
+        "AdminEmail"        : {
+            "Description" : "Email adress of applications administrator. If user sends more than X files a day, notification about it will be sent to that email address. You will need to confirm this address.",
+            "Type"        : "String",
+            "MinLength"   : 3,
+            "MaxLength"   : 255
+        },
+        "NotificationThreshold" : {
+            "Description" : "Amount of files uploaded one day that will cause a notification to be sent to administrator.",
+            "Type"        : "Number",
+            "MinValue"    : "1"
         }
     },
     "Resources"   : {
@@ -84,7 +95,7 @@
                 }
             }
         },
-        "S3Endpoint"  : {
+        "S3Endpoint" : {
             "Type" : "AWS::EC2::VPCEndpoint",
             "Properties" : {
                 "RouteTableIds" : [
@@ -118,7 +129,10 @@
                         {
                             "Effect" : "Allow",
                             "Principal" : "*",
-                            "Action"    : ["s3:Get*", "s3:List*"],
+                            "Action"    : [
+                                "s3:Get*",
+                                "s3:List*"
+                            ],
                             "Resource"  : [
                                 "arn:aws:s3:::*"
                             ]
@@ -135,7 +149,7 @@
                 }
             }
         },
-        "Function"    : {
+        "Function"   : {
             "Type" : "AWS::Lambda::Function",
             "Properties" : {
                 "Code" : {
@@ -159,13 +173,20 @@
                                 "Fn::Sub" : "${DatabaseStackName}-Endpoint"
                             }
                         },
-                        "S3ACCESSPOINT" : { "Ref": "AppsS3BucketName"
+                        "S3ACCESSPOINT" : {
+                            "Ref" : "AppsS3BucketName"
                         },
                         "USER"          : {
                             "Ref" : "DBUsername"
                         },
                         "PASSWORD"      : {
                             "Ref" : "DBPassword"
+                        },
+                        "LOGLIMIT"      : {
+                            "Ref" : "NotificationThreshold"
+                        },
+                        "TOPICARN"      : {
+                            "Ref" : "SNSTopic"
                         }
                     }
                 },
@@ -177,7 +198,7 @@
                     ]
                 },
                 "Runtime"     : "dotnetcore3.1",
-                "Timeout"     : 30,
+                "Timeout"     : 60,
                 "VpcConfig"   : {
                     "SubnetIds" : [
                         {
@@ -217,7 +238,8 @@
                 },
                 "ManagedPolicyArns"        : [
                     "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
-                    "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+                    "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+                    "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
                 ],
                 "Tags"                     : [
                     {
@@ -263,12 +285,158 @@
                     "Fn::Sub" : "arn:aws:s3:::${AppsS3BucketName}"
                 }
             }
+        },
+        "SNSTopic"              : {
+            "Type" : "AWS::SNS::Topic",
+            "Properties" : {
+                "DisplayName" : "Too much logs",
+                "Subscription" : [
+                    {
+                        "Protocol" : "email",
+                        "Endpoint" : {
+                            "Ref" : "AdminEmail"
+                        }
+                    }
+                ]
+            }
+        },
+        "SNSTopicPolicy"        : {
+            "Type" : "AWS::SNS::TopicPolicy",
+            "Properties" : {
+                "Topics" : [
+                    {
+                        "Ref" : "SNSTopic"
+                    }
+                ],
+                "PolicyDocument" : {
+                    "Version" : "2008-10-17",
+                    "Id"      : "__default_policy_ID",
+                    "Statement" : [
+                        {
+                            "Sid" : "__default_statement_ID",
+                            "Effect" : "Allow",
+                            "Principal" : {
+                                "AWS" : "*"
+                            },
+                            "Action"    : [
+                                "SNS:Publish",
+                                "SNS:RemovePermission",
+                                "SNS:SetTopicAttributes",
+                                "SNS:DeleteTopic",
+                                "SNS:ListSubscriptionsByTopic",
+                                "SNS:GetTopicAttributes",
+                                "SNS:Receive",
+                                "SNS:AddPermission",
+                                "SNS:Subscribe"
+                            ],
+                            "Resource"  : {
+                                "Ref" : "SNSTopic"
+                            },
+                            "Condition" : {
+                                "StringEquals" : {
+                                    "AWS:SourceOwner" : {
+                                        "Ref" : "AWS::AccountId"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Sid" : "__console_pub_0",
+                            "Effect" : "Allow",
+                            "Principal" : {
+                                "AWS" : "*"
+                            },
+                            "Action"    : "SNS:Publish",
+                            "Resource"  : {
+                                "Ref" : "SNSTopic"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "SNSEndpoint"           : {
+            "Type" : "AWS::EC2::VPCEndpoint",
+            "Properties" : {
+                "PolicyDocument" : {
+                    "Statement" : [
+                        {
+                            "Effect" : "Allow",
+                            "Principal" : "*",
+                            "Action"    : "*",
+                            "Resource"  : "*"
+                        }
+                    ]
+                },
+                "ServiceName"    : {
+                    "Fn::Sub" : "com.amazonaws.${AWS::Region}.sns"
+                },
+                "VpcId"          : {
+                    "Fn::ImportValue" : {
+                        "Fn::Sub" : "${NetworkStackName}-VPCID"
+                    }
+                },
+                "SecurityGroupIds" : [
+                    {
+                        "Fn::GetAtt" : [
+                            "SNSEndpointSecurityGroup",
+                            "GroupId"
+                        ]
+                    }
+                ],
+                "SubnetIds"        : [
+                    {
+                        "Fn::ImportValue" : {
+                            "Fn::Sub" : "${NetworkStackName}-PublicSubnet1"
+                        }
+                    },
+                    {
+                        "Fn::ImportValue" : {
+                            "Fn::Sub" : "${NetworkStackName}-PublicSubnet2"
+                        }
+                    }
+                ],
+                "VpcEndpointType"  : "Interface",
+                "PrivateDnsEnabled" : true
+            }
+        },
+        "SNSEndpointSecurityGroup" : {
+            "Type" : "AWS::EC2::SecurityGroup",
+            "Properties" : {
+                "GroupName" : "sns-endpoint-sg",
+                "GroupDescription" : "Security group for SNS VPC endpoint",
+                "VpcId"            : {
+                    "Fn::ImportValue" : {
+                        "Fn::Sub" : "${NetworkStackName}-VPCID"
+                    }
+                },
+                "SecurityGroupIngress" : [
+                    {
+                        "SourceSecurityGroupId" : {
+                            "Fn::GetAtt" : [
+                                "FunctionSecurityGroup",
+                                "GroupId"
+                            ]
+                        },
+                        "IpProtocol"            : "tcp",
+                        "FromPort"              : "1",
+                        "ToPort"                : "65535"
+                    }
+                ],
+                "Tags"                 : [
+                    {
+                        "Key" : "Name",
+                        "Value" : "access-analyser SNS VPC endpoint Security group"
+                    }
+                ]
+            }
         }
     },
     "Outputs"     : {
         "S3BucketName" : {
             "Description" : "Name of created S3 bucket",
-            "Value"       : { "Ref": "AppsS3BucketName"
+            "Value"       : {
+                "Ref" : "AppsS3BucketName"
             },
             "Export"      : {
                 "Name" : {


### PR DESCRIPTION
Lambda publikuje powiadomienie do SNS, a on wysyła maila na adres podany w template cloud formation. Przykładowa wiadomość:
Temat: Access.analyser - too many logs
User sent too many logs today, objectKey ({userId}-{TodaysDate}-{#of log sent today}.log)=aa037f6f-03b3-4f08-a1a6-508d893804dd-04.06.2020-15.log
closes #16